### PR TITLE
docs: Agregar links de documentos relacionados y atender a retro

### DIFF
--- a/docs/procesos/P08-proceso-gestion-riesgos.md
+++ b/docs/procesos/P08-proceso-gestion-riesgos.md
@@ -1,5 +1,5 @@
 
-# P08 - Proceso gestión de riesgos
+# P08 - Proceso de gestión de riesgos
 
 ## Objetivo(s)
 
@@ -16,10 +16,10 @@
 
 | Fase |   Actividades   | Área(s) involucradas |
 |------|:---------------:|--------------------|
-| 1. Identificación | <ul><li>Abrir la Matriz de riesgos</li><li> Consultar la Guía para definir riesgos </li><li>Describir el riesgo y categorizarlo</li></ul> |<ul><li>RKM - 1.1</li><li>RKM - 1.2</li><li>RKM -2.1</li> <li>PP - 2.2</li></ul> |
+| 1. Identificación | <ul><li>Abrir la [Matriz de riesgos departamental](https://docs.google.com/spreadsheets/d/1L_IWQMrYGR4vnJVB-YF48OHtPyNLnXWxmzz2g-aHHGM/edit#gid=0), [Matriz de riesgos de Frappé](https://docs.google.com/spreadsheets/d/11f-Dfe_lYfQPmQ0-v8wUIxH0FNwlYDN0DKBrRPcf1ks/edit#gid=0), o [Matriz de riesgos de Espresso](https://docs.google.com/spreadsheets/d/1JnAqpLpd-TLpKlqAa5cpC9Z8KsISirue2D7bM9T4GQQ/edit#gid=0)</li><li> Consultar la [Guía para definir riesgos](../guias/G06-guia-definicion-riesgos.md) </li><li>Describir el riesgo y categorizarlo de acuerdo a las categorías dentro de la guía</li></ul> |<ul><li>RKM - 1.1</li><li>RKM - 1.2</li><li>RKM -2.1</li> <li>PP - 2.2</li></ul> |
 | 2. Análisis | <ul><li>Definir  la probabilidad de que el riesgo ocurra (en porcentaje) </li><li> Definir el impacto que tendría el riesgo en caso de ocurrir (en una escala del 1 - 10) </li><li> Definir la magnitud del riesgo multiplicando la probabilidad con el impacto </li></ul> | <ul><li>RKM - 2.2</li><li>PP - 2.2</li></ul> |
-| 3. Estrategias | <ul><li> En caso de que el riesgo dependa del departamento se plantea un plan de mitigación (de lo contrario no se hace)</li><li> Definir un plan de contingencia </li><li> En caso de que el riesgo sea de magnitud alta, agregar el plan de mitigación como work item </li><li>Asignar un responsable para monitorear el riesgo </li></ul> | <ul><li>RKM - 3.1</li><li>PMC - 1.3</li></ul> |
-|4. Documentación| <ul><li> Documentar los cambios realizados en la bitácora de cambios del plan de riesgos </li></ul>| <ul><li>RKM - 3.2</li></ul> |
+| 3. Estrategias | <ul><li> En caso de que el riesgo dependa del departamento se plantea un plan de mitigación (de lo contrario no se hace)</li><li> Definir un plan de contingencia </li><li> En caso de que el riesgo sea de magnitud alta (más de 6.0), agregar el plan de mitigación como work item </li></ul> | <ul><li>RKM - 3.1</li><li>PMC - 1.3</li></ul> |
+|4. Documentación| <ul><li> Documentar los cambios realizados en la bitácora de cambios del plan de riesgos, con la fecha de modificación y el autor de la misma </li></ul>| <ul><li>RKM - 3.2</li></ul> |
 
 ## Salidas
 


### PR DESCRIPTION
Se agregaron los links a todos los documentos pertinentes, se retiró la asignación de un responsable por riesgo, y se especificó la magnitud requerida para que se cree un ítem de trabajo a partir del riesgo.