### PR TITLE
docs: añadir matriz de retrospectives

### DIFF
--- a/docs/procesos/P20-proceso-retrospective.md
+++ b/docs/procesos/P20-proceso-retrospective.md
@@ -26,6 +26,7 @@ Datos, gráficas, índice CPI y SPI de la iteración.
           <li>En el dashboard, haz click en "Add board" para crear un nuevo tablero. </li>
           <li>Nombra el tablero "Retrospectiva SP[# iteración], permite 5 votos por participante y haz habilita las opciones de "Hide cards initially", "Disable voting initially" </li>
           <li>Agrega las columnas Start doing, Continue doing, Stop doing y Kudos. Haz click en "Create".</li>
+          <li>Añadir el link del tablero a la <a href="https://docs.google.com/spreadsheets/d/1uYSPo966wNlzTGg_xeQxHO8dOu2z2sIsBVoq0DF8umo/edit#gid=53563502">Matriz de Retrospectives</a>.</li>
         </ol>
       </td>
       <td>

--- a/docs/procesos/P20-proceso-retrospective.md
+++ b/docs/procesos/P20-proceso-retrospective.md
@@ -109,14 +109,18 @@ Plan para la mejora del WoW
 
 ## Autores
 
-Karla Daniela Romero Pérez
+- Karla Daniela Romero Pérez
+- Eduardo Guzmán
 
 ## Auditoría
-- 
+- Raúl Rosario Gálavi<
 
 # Bitácora de cambios
 
 ## Versión 1.0
   - Se creó el proceso.
+
+## Versión 1.1
+  - Se añadió el link a la matriz de retrospectives
 
 

--- a/docs/procesos/P20-proceso-retrospective.md
+++ b/docs/procesos/P20-proceso-retrospective.md
@@ -113,7 +113,7 @@ Plan para la mejora del WoW
 - Eduardo Guzmán
 
 ## Auditoría
-- Raúl Rosario Gálavi<
+- Raúl Rosario Gálaviz
 
 # Bitácora de cambios
 


### PR DESCRIPTION
Se añadió un paso de añadir el link del board a la matriz de retrospectives, para PP en lecciones aprendidas